### PR TITLE
load dev script via query parameter

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -146,7 +146,15 @@
       <i class="fa fa-copyright" aria-hidden="true"> 2017 The Black Pot</i>
     </footer>
     <script src="js/jquery-3.2.1.js"></script>
-    <script src="js/main.js"></script>
+    <script>
+    (function() {
+      var useDevScript = (document.location.search.indexOf('devscript') !== -1);
+      var src = useDevScript ? 'js/main.js' : 'js/main.min.js';
+      var scriptEl = document.createElement('script');
+      scriptEl.src = src;
+      document.body.appendChild(scriptEl);
+    })();
+    </script>
     <script async defer
      src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDVxQERF4WSusdYUnswuFuJ7kM59HEkGb4&callback=map"></script>
     <script id="dsq-count-scr" src="//the-black-pot.disqus.com/count.js" async></script>


### PR DESCRIPTION
Dynamically load the main JS file without having to modify `index.html`

- Loads `js/main.min.js` by default.
- Loads `js/main.js` if you add a query parameter to the page. ie: `index.html?devscript=1`